### PR TITLE
Update 05_WCR_OPT_WaterDetection.rsx

### DIFF
--- a/rscripts/GWA_TBX/05_WCR_OPT_WaterDetection.rsx
+++ b/rscripts/GWA_TBX/05_WCR_OPT_WaterDetection.rsx
@@ -28,7 +28,7 @@
 ##Minimum_mapping_unit = number 3
 ##Plot_water_probability= Boolean False
 ##Plot_certainty_indicator= Boolean False
-##Tile_size= number 2000 
+ 
 
 
 # LOAD LIBRARIES -------------------------------------------------------
@@ -48,6 +48,5 @@ WCR_workflow(Directory_containing_indices,
              End_Date,
              Minimum_mapping_unit,
              Plot_certainty_indicator,
-             Plot_water_probability,
-             Tile_size)
+             Plot_water_probability)
              


### PR DESCRIPTION
removed tile-size option, because it is not a valid option since v1.3. The tile-size is a fix value 